### PR TITLE
Added sh install to dockerfile

### DIFF
--- a/dockerFiles/Docker
+++ b/dockerFiles/Docker
@@ -49,5 +49,5 @@ RUN pip install quantcrypt && \
     pip install pycryptodome && \
     pip install Flask && \
 	pip install watchdog && \
-    pip install password-strength \
+    pip install password-strength && \
     pip install sh

--- a/dockerFiles/Docker
+++ b/dockerFiles/Docker
@@ -49,4 +49,5 @@ RUN pip install quantcrypt && \
     pip install pycryptodome && \
     pip install Flask && \
 	pip install watchdog && \
-    pip install password-strength
+    pip install password-strength \
+    pip install sh


### PR DESCRIPTION
When running logPoster from non-genesis node I hit:`ModuleNotFoundError: No module named 'sh'`

Saw that watchDog.py imports tail from sh, which isn't included in default python install.

Instead of manually installing sh inside containers - changed dockerfile to include in build.